### PR TITLE
Move CLI args to config file

### DIFF
--- a/arduino-service/.arduino-config.json
+++ b/arduino-service/.arduino-config.json
@@ -1,0 +1,14 @@
+{
+    "sketch": "/home/pi/Arduino/nbiot-e2e/device",
+    "logDir": "/home/pi/log",
+    "gitDirs": [
+        "/home/pi/Arduino/nbiot-e2e",
+        "/home/pi/Arduino/libraries/ArduinoNBIoT"
+    ],
+    "boards": [
+        {
+            "fqbn": "arduino:avr:uno",
+            "port": "/dev/ttyACM0"
+        }
+    ]
+}

--- a/arduino-service/arduino.service
+++ b/arduino-service/arduino.service
@@ -4,13 +4,7 @@ After=network.target
 
 [Service]
 Environment="PATH=/usr/local/go/bin:/home/pi/go/bin"
-ExecStart=/home/pi/Arduino/nbiot-e2e/arduino-service/arduino-service \
-    --board-fqbn arduino:avr:uno \
-    --port /dev/ttyACM0 \
-    --sketch /home/pi/Arduino/nbiot-e2e/device \
-    --log-dir /home/pi/log \
-    --git-dir /home/pi/Arduino/nbiot-e2e \
-    --git-dir /home/pi/Arduino/libraries/ArduinoNBIoT
+ExecStart=/home/pi/Arduino/nbiot-e2e/arduino-service/arduino-service
 WorkingDirectory=/home/pi/Arduino/nbiot-e2e/arduino-service
 StandardOutput=inherit
 StandardError=inherit

--- a/arduino-service/config.go
+++ b/arduino-service/config.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+const configFileName = ".arduino-config.json"
+
+type Config struct {
+	Sketch  string   `json:"sketch"`
+	LogDir  string   `json:"logDir"`
+	GitDirs []string `json:"gitDirs"`
+	Boards  []Board  `json:"boards"`
+}
+
+type Board struct {
+	ArduinoFQBN string `json:"fqbn"`
+	Port        string `json:"port"`
+}
+
+func readConfig() (config Config, err error) {
+	configFile, err := os.Open(getFullPath(configFileName))
+	if err != nil {
+		return config, err
+	}
+	defer configFile.Close()
+
+	bytes, err := ioutil.ReadAll(configFile)
+	if err != nil {
+		return config, err
+	}
+
+	err = json.Unmarshal(bytes, &config)
+	if err != nil {
+		return config, err
+	}
+	return config, nil
+}
+
+func getFullPath(filename string) string {
+	usr, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(usr.HomeDir, filename)
+}

--- a/arduino-service/main.go
+++ b/arduino-service/main.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/jessevdk/go-flags"
 	"gopkg.in/src-d/go-git.v4"
 )
 
@@ -18,50 +17,34 @@ type gitHash struct {
 func main() {
 	log.SetFlags(log.Ldate | log.Ltime)
 
-	var opts struct {
-		Boards  []string `short:"b"    long:"board-fqbn"     required:"true"    description:"Arduino FQBN"`
-		Ports   []string `short:"p"    long:"port"           required:"true"    description:"USB Port"`
-		Sketch  string   `short:"s"    long:"sketch"         required:"true"    description:"Sketch to upload when git-dir changes"`
-		LogDir  string   `short:"l"    long:"log-dir"        required:"true"    description:"Directory to store log files"`
-		GitDirs []string `short:"g"    long:"git-dir"        required:"true"    description:"Git repo folder for including latest commit hash in payload"`
-	}
-	_, err := flags.Parse(&opts)
+	config, err := readConfig()
 	if err != nil {
-		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
-			os.Exit(0)
-		}
-		os.Exit(1)
-	}
-
-	if _, err := os.Stat(opts.Sketch); os.IsNotExist(err) {
 		log.Fatalln(err)
 	}
 
-	if stat, err := os.Stat(opts.LogDir); os.IsNotExist(err) {
+	if _, err := os.Stat(config.Sketch); os.IsNotExist(err) {
+		log.Fatalln(err)
+	}
+
+	if stat, err := os.Stat(config.LogDir); os.IsNotExist(err) {
 		log.Fatalln(err)
 	} else if !stat.IsDir() {
-		log.Fatalf("%s is not a directory", opts.LogDir)
+		log.Fatalf("%s is not a directory", config.LogDir)
 	}
 
-	if len(opts.Boards) > len(opts.Ports) {
-		log.Fatalln("Error: more boards than ports")
-	} else if len(opts.Ports) > len(opts.Boards) {
-		log.Fatalln("Error: more ports than boards")
-	}
+	for _, b := range config.Boards {
+		logName := path.Join(config.LogDir, strings.Replace(b.ArduinoFQBN, ":", "-", -1)+".log")
+		a := NewArduino(b.ArduinoFQBN, b.Port, logName)
 
-	for i, b := range opts.Boards {
-		logName := path.Join(opts.LogDir, strings.Replace(b, ":", "-", -1)+".log")
-		a := NewArduino(b, opts.Ports[i], logName)
-
-		if err := a.Compile(opts.Sketch, gitHashes(opts.GitDirs)); err != nil {
+		if err := a.Compile(config.Sketch, gitHashes(config.GitDirs)); err != nil {
 			log.Println("Error: ", err)
 		} else {
-			if err = a.Upload(opts.Sketch); err != nil {
+			if err = a.Upload(config.Sketch); err != nil {
 				log.Println("Error: ", err)
 			}
 		}
 
-		log.Printf("Starting serial monitor for %s %s\n", opts.Boards[0], opts.Ports[0])
+		log.Printf("Starting serial monitor for %s %s\n", b.ArduinoFQBN, b.Port)
 		go a.MonitorSerial()
 	}
 


### PR DESCRIPTION
So the `arduino.service` file doesn't need to be modified to add/remove arguments. Then you only copy the default config to the home directory and modify it depending on what boards to use.